### PR TITLE
Align README install instructions and those in create tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Editing
+.vscode

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Hope it can help you!
 Git clone the repository in a path and setup your $PATH to call the scripts from
 anywhere. For instance:
 
-    git clone git@githuh.com:damofthemoon/svut.git $HOME/.svut
+    git clone git@github.com:damofthemoon/svut.git $HOME/.svut
     export PATH=$HOME/.svut/:$PATH
 
 ### How to use it

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Hope it can help you!
 
 ### How to install it
 
-Git clone the repository in a path and setup your $PATH to call the scripts from
-anywhere. For instance:
+Git clone the repository in a path. Set up the SVUT environment variable 
+and add SVUT to $PATH:
 
     git clone git@github.com:damofthemoon/svut.git $HOME/.svut
-    export PATH=$HOME/.svut/:$PATH
+    export SVUT=$HOME/.svut
+    export PATH=$SVUT:$PATH
 
 ### How to use it
 

--- a/svutCreate.py
+++ b/svutCreate.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
     print ""
     print "      To launch SVUT, don't forget to setup its environment variable. For instance:"
     print ""
-    print "      export SVUT=\"HOME/.svut\""
+    print "      export SVUT=\"$HOME/.svut\""
     print "      export PATH=$SVUT:$PATH"
     print ""
     print "      You can find a Makefile example to launch your unit test in your SVUT install folder"


### PR DESCRIPTION
The README didn't quite match the setup instructions printed by the svutCreate (and the tool needs a $ before HOME). This patches both the tool and the README to be consistent.

Also patches .gitignore to allow Visual Studio Code as a 