### PR TITLE
Display test name, suite name, and reason for failure. Adds JUnit-style macros.

### DIFF
--- a/svutRun.py
+++ b/svutRun.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
 
     ARGS = PARSER.parse_args()
 
-    if "all" in [t.lower() for t in ARGS.test]:
+    if ARGS.test == "all" or "all" in [t.lower() for t in ARGS.test]:
         ARGS.test = find_unit_tests()
 
     for tests in ARGS.test:


### PR DESCRIPTION
1. Adds optional `reason` parameter to all check macros to explain the failure. (FYI, also adds a second optional message to `ERROR(msg, [msg2])` to display reason.)
2. *Breaking change* In `UNIT_TEST(name)`, changed `name` to a string (from a label) so name can be printed at test time. 
3. Adds `TEST_SUITE(name)` and `END_TEST_SUITE` macros to allowed named test suites. (`UNIT_TESTS` and `UNIT_TESTS_END` are still available.)
4. Adds `ASSERT(test, [reason])` and `ASSERT_EQUALS(expression, value, [reason])` to match other -Unit style frameworks.
5. Adds comments to the file to make navigation easier.