### PR TITLE
Ensure the tests being run reflect latest source

### DIFF
--- a/svutRun.py
+++ b/svutRun.py
@@ -53,7 +53,9 @@ def create_iverilog(args, test):
     """
     Create the Icarus Verilog command to launch the simulation
     """
-    cmds = []
+    # Remove the compiled file if it exists. That ensures that a compilation error
+    # won't run an obsolete test instead
+    cmds = ["rm -f a.out"]
     cmd = "iverilog -g2012 "
 
     if args.dotfile:


### PR DESCRIPTION
Fixes #9 using the easiest route possible: removing a.out (when using icarus verilog) before compiling. Silently handles when a.out doesn't exist. This makes test-driven development easier as you don't run the risk of accidentally running an old test when a new test doesn't compile.