### PR TITLE
Help Github's license detector recognize this

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
-"""
-Copyright 2019 The SVUT Authors
+The MIT License
+
+Copyright (c) 2019 The SVUT Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -15,4 +16,3 @@ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPO
 IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-"""


### PR DESCRIPTION
Dropping markdown quote wrappers, aligning copyright clause to other MIT licenses, and tagging the first line as MIT. (Basically, syncing this to other, properly detected, MIT licenses.)